### PR TITLE
Add validation of specified serial port

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,11 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: [ testing ]
+    branches: [ main ]
   pull_request:
-    branches: [ testing ]
+    branches: [ main ]
   create:
-    branches: [ testing ]
+    branches: [ main ]
     tags: ['**']
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ magneto 0.0.3
   communication error occurs with the stimulator.
 * Fixed rare startup crash when Magstim sends a message consisting only of null
   bytes.
+* Added a check to ensure the requested serial port exists on the system when
+  initializing a Magstim class, raising an informative exception if it doesn't.
 
 
 magneto 0.0.2

--- a/magneto/tests/test_magstim.py
+++ b/magneto/tests/test_magstim.py
@@ -1,5 +1,7 @@
 
 import pytest
+from unittest import mock
+
 import time
 from queue import Queue
 from magneto import Magstim
@@ -11,7 +13,9 @@ from magneto.constants import *
 
 @pytest.fixture()
 def mockstim():
-    tst = Magstim("COM1")
+    with mock.patch("magneto.magstim._get_available_ports") as get_ports:
+        get_ports.return_value = ['COM1']
+        tst = Magstim("COM1")
     tst._from_stim = Queue()
     tst._to_stim = Queue()
     tst._com_thread = True
@@ -26,7 +30,11 @@ def add_to_queue(magstim, cmds):
 class TestMagstim(object):
 
     def test_init(self):
-        tst = Magstim("COM1")
+        with mock.patch("magneto.magstim._get_available_ports") as get_ports:
+            get_ports.return_value = ['COM1', 'COM4']
+            tst = Magstim("COM1")
+            with pytest.raises(RuntimeError):
+                tst = Magstim("COM3")
 
     def test_pump(self, mockstim):
         tst = mockstim

--- a/magneto/utils.py
+++ b/magneto/utils.py
@@ -85,4 +85,4 @@ def _validate_response(resp):
 
 def _get_available_ports():
     # Returns a list of all available serial ports
-    return [p.device for p in comports()]
+    return [p.device for p in comports() if not "Bluetooth" in p.device]


### PR DESCRIPTION
Adds a check to make sure the requested serial port for a Magstim exists on the current system, and raises an informative error if it doesn't. Should make troubleshooting cross-system/cross-platform issues easier.